### PR TITLE
Configure base path for GitHub Pages

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,7 @@ import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: process.env.NODE_ENV === 'production' ? '/React_proj-apps/' : '/',
   plugins: [react()],
   test: {
     globals: true,


### PR DESCRIPTION
## Summary
- add environment-based base path in `vite.config.js`

## Testing
- `npm test` *(fails: `vitest` not found)*
- `npm install` *(fails: ERESOLVE could not resolve)*

------
https://chatgpt.com/codex/tasks/task_e_684ff92337348332a6284b3dee30d51d