### PR TITLE
Add startup script

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
   "updateContentCommand": "npm install",
   "postCreateCommand": "",
   "postAttachCommand": {
-    "server": "npm start"
+    "server": ".devcontainer/startup.sh"
   },
   "customizations": {
     "codespaces": {

--- a/.devcontainer/startup.sh
+++ b/.devcontainer/startup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Startup script to prepare environment when container initializes
+set -e
+
+# Ensure Node dependencies are installed
+npm install
+
+# Start development server
+npm start


### PR DESCRIPTION
## Summary
- add startup script for devcontainer to run npm install and start automatically

## Testing
- `npm test --silent` *(fails to exit automatically; terminated with CTRL+C)*

------
https://chatgpt.com/codex/tasks/task_e_6850783820208332b81fd1ed657ed416