### PR TITLE
Add GitHub Pages workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy to GitHub Pages
+on:
+  push:
+    branches: [main]
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: docs
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - id: deploy
+        uses: actions/deploy-pages@v2

--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,6 @@ dist
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# GitHub Pages build output
+/docs

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This section has moved here: [https://vitejs.dev/guide/build.html#advanced-base-
 
 ### Deployment
 
-This section has moved here: [https://vitejs.dev/guide/build.html](https://vitejs.dev/guide/build.html)
+This project is preconfigured for GitHub Pages. The workflow in `.github/workflows/deploy.yml` builds the app and deploys the `docs` folder whenever changes land on `main`. To test locally run `npm run build` and open `docs/index.html`.
 
 ### Troubleshooting
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,9 @@ import react from "@vitejs/plugin-react";
 // https://vitejs.dev/config/
 export default defineConfig({
   base: process.env.NODE_ENV === 'production' ? '/React_proj-apps/' : '/',
+  build: {
+    outDir: 'docs',
+  },
   plugins: [react()],
   test: {
     globals: true,


### PR DESCRIPTION
## Summary
- remove compiled `docs` assets from version control
- ignore the `docs` folder
- add a GitHub Actions workflow that builds and deploys on push to `main`
- document GitHub Pages deployment in the README

## Testing
- `npm run build`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68507f73ca608332b3971da71988fb41