### PR TITLE
Fix GH Pages asset paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This project is an interactive demo of how Active Inference principles can guide
    ```bash
    npm run build
    ```
-   The optimized output is written to the `docs` folder. This folder is configured for deployment to GitHub Pages.
+   The optimized output is written to `docs/apps/project-management-simulation`. This folder is configured for deployment to GitHub Pages.
 
 5. **Preview the production build locally**
    ```bash
@@ -40,7 +40,7 @@ This project is an interactive demo of how Active Inference principles can guide
 
 ## Deployment
 
-A workflow in `.github/workflows/deploy.yml` builds the project and publishes the contents of the `docs` directory whenever changes land on the `main` branch. You can run the same build locally with `npm run build` and open `docs/index.html` to verify the result.
+A workflow in `.github/workflows/deploy.yml` builds the project and publishes the contents of the `docs` directory whenever changes land on the `main` branch. You can run the same build locally with `npm run build` and open `docs/apps/project-management-simulation/index.html` to verify the result.
 
 ## Learn More
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,7 +8,10 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // https://vitejs.dev/config/
 export default defineConfig({
   root: resolve(__dirname, 'apps/project-management-simulation'),
-  base: process.env.NODE_ENV === 'production' ? '/React_proj-apps/' : '/',
+  base:
+    process.env.NODE_ENV === 'production'
+      ? '/React_proj-apps/apps/project-management-simulation/'
+      : '/',
   build: {
     outDir: resolve(__dirname, 'docs/apps/project-management-simulation'),
   },


### PR DESCRIPTION
## Summary
- fix base path in `vite.config.js` so production builds reference the correct asset directory
- update README instructions with the new build location

## Testing
- `npm test --silent`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6851c42c71cc833285d4595f2b22c176