### PR TITLE
Fix site index build

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "start": "BROWSER=none WDS_SOCKET_PORT=0 vite --port 3000",
-    "build": "vite build",
+    "build": "vite build && cp index.html docs/index.html && cp app-index.csv docs/app-index.csv && cp -r pics docs/pics",
     "preview": "vite preview",
     "test": "vitest"
   },


### PR DESCRIPTION
## Summary
- include root index and assets when building the project

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851c5132c6083328530174446861132