### PR TITLE
Fix dynamic app builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Project Management Simulation with Active Inference
+# Project Apps
 
-This project is an interactive demo of how Active Inference principles can guide project management decisions. It is built with **React** and **Vite** and visualizes estimations, progress and resource allocation using [Recharts](https://recharts.org/).
+This repository hosts a collection of small React applications. The main example is a **Project Management Simulation** implementing Active Inference principles. A second app, **Project Dynamics Simulator**, explores feedback loops in projects. All apps are built with **Vite** and use [Recharts](https://recharts.org/) for charts.
 
 ## Getting Started
 
@@ -12,7 +12,12 @@ This project is an interactive demo of how Active Inference principles can guide
    ```bash
    npm start
    ```
-   The app will be available at [http://localhost:3000](http://localhost:3000). The page reloads automatically when files change.
+   By default this serves the Project Management Simulation at [http://localhost:3000](http://localhost:3000).
+   To work on the Project Dynamics Simulator run:
+   ```bash
+   APP=project-dynamics-simulator npm start
+   ```
+   The page reloads automatically when files change.
 
 3. **Run tests**
    ```bash
@@ -24,11 +29,15 @@ This project is an interactive demo of how Active Inference principles can guide
    ```bash
    npm run build
    ```
-   The optimized output is written to `docs/apps/project-management-simulation`. This folder is configured for deployment to GitHub Pages.
+   This builds **both** applications and writes the output under `docs/apps/`. The folder is configured for deployment to GitHub Pages.
 
 5. **Preview the production build locally**
    ```bash
    npm run preview
+   ```
+   Pass `APP=<app-name>` to preview a specific build, e.g.
+   ```bash
+   APP=project-dynamics-simulator npm run preview
    ```
 
 ## Project Structure

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "start": "BROWSER=none WDS_SOCKET_PORT=0 vite --port 3000",
-    "build": "vite build && cp index.html docs/index.html && cp app-index.csv docs/app-index.csv && cp -r pics docs/pics",
+    "build": "APP=project-management-simulation vite build && APP=project-dynamics-simulator vite build && cp index.html docs/index.html && cp app-index.csv docs/app-index.csv && cp -r pics docs/pics",
     "preview": "vite preview",
     "test": "vitest"
   },

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,14 +6,16 @@ import { fileURLToPath } from 'url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // https://vitejs.dev/config/
+const appName = process.env.APP || 'project-management-simulation';
+
 export default defineConfig({
-  root: resolve(__dirname, 'apps/project-management-simulation'),
+  root: resolve(__dirname, `apps/${appName}`),
   base:
     process.env.NODE_ENV === 'production'
-      ? '/React_proj-apps/apps/project-management-simulation/'
+      ? `/React_proj-apps/apps/${appName}/`
       : '/',
   build: {
-    outDir: resolve(__dirname, 'docs/apps/project-management-simulation'),
+    outDir: resolve(__dirname, `docs/apps/${appName}`),
   },
   plugins: [react()],
   test: {


### PR DESCRIPTION
## Summary
- allow `APP` env variable to pick which app to build/run
- build both apps during CI
- document new workflow in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851e8f0cbd0833288242aa98c24f518