### PR TITLE
Add build script for multi-apps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 # Project Apps Repository
 
-This repository hosts a set of React applications built with Vite. The primary application at the moment is a **Project Management Simulation** demonstrating Friston's Active Inference principles applied to project planning.
+This repository hosts a growing collection of React applications built with Vite. The first app was a **Project Management Simulation** demonstrating Active Inference principles. A second app explores project dynamics. More apps may be added over time.
 
-## Current Application: Project Management Simulation
+## Application: Project Management Simulation
 
 ### Overview
 - Located in `apps/project-management-simulation/src/App.tsx` and bootstrapped by `apps/project-management-simulation/src/index.jsx`.
@@ -25,9 +25,9 @@ This repository hosts a set of React applications built with Vite. The primary a
 - Toggle display of Active Inference insights.
 
 ### Running and Testing
-- `npm start` launches a development server on port `3000`.
+- `npm start` launches a development server on port `3000`. Set `APP=<app-name>` to work on a different app.
 - `npm test` runs the Vitest test suite (see `apps/project-management-simulation/src/App.test.tsx`).
-- Production builds output to the `docs/apps/project-management-simulation` directory (`vite.config.js`).
+- `npm run build` executes `scripts/build-all.js` which builds every app under `apps/` and outputs them to `docs/apps/<app-name>`.
 
 ## Application: Project Dynamics Simulator
 
@@ -36,7 +36,7 @@ This second app explores reinforcing and balancing feedback loops in a project e
 - Located in `apps/project-dynamics-simulator/src/App.tsx` and bootstrapped by `apps/project-dynamics-simulator/src/index.jsx`.
 - Visualises progress, scope, quality, morale and other metrics with **Recharts**.
 - Toggle effects like technical debt, team learning and user feedback to see non-linear project behaviour.
-- To develop this app locally, temporarily set `root` in `vite.config.js` to `apps/project-dynamics-simulator` before running `npm start`.
+To work on this app locally run `APP=project-dynamics-simulator npm start`.
 
 ## Future Applications
 This repository is intended to host multiple project-oriented apps. Each app should live in `apps/<app-name>` with its own `src` folder and `index.html`. Shared utilities such as `index.css`, `reportWebVitals.js` and test setup files belong in `src/common` so they can be imported across apps. Application-specific components and styles should remain under their respective app directory. The root `index.html` displays a card index of all available apps using `app-index.csv` and screenshots stored in `pics/`.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ This repository hosts a collection of small React applications. The main example
    ```bash
    npm run build
    ```
-   This builds **both** applications and writes the output under `docs/apps/`. The folder is configured for deployment to GitHub Pages.
+   The build script automatically iterates over every folder in `apps/` and writes the optimized output under `docs/apps/<app-name>`.
+   The folder is configured for deployment to GitHub Pages.
 
 5. **Preview the production build locally**
    ```bash
@@ -42,14 +43,14 @@ This repository hosts a collection of small React applications. The main example
 
 ## Project Structure
 
-- `src/App.tsx` – main simulation component with minimal UI helpers.
-- `src/App.test.tsx` – example unit test using Vitest and React Testing Library.
-- `public/` – static assets and `index.html` template.
-- `vite.config.js` – Vite configuration. When `NODE_ENV` is `production`, the base path is set for GitHub Pages (`/React_proj-apps/`).
+- `apps/<app-name>/` – individual applications. Each folder contains its own `src` and `index.html`.
+- `src/common/` – shared utilities like `index.css`, `reportWebVitals.js` and test setup.
+- `vite.config.js` – uses the `APP` environment variable to select which app to serve or build.
+- `scripts/build-all.js` – helper script run by `npm run build` to build every app found in `apps/`.
 
 ## Deployment
 
-A workflow in `.github/workflows/deploy.yml` builds the project and publishes the contents of the `docs` directory whenever changes land on the `main` branch. You can run the same build locally with `npm run build` and open `docs/apps/project-management-simulation/index.html` to verify the result.
+A workflow in `.github/workflows/deploy.yml` builds the project and publishes the contents of the `docs` directory whenever changes land on the `main` branch. You can run the same build locally with `npm run build` and open `docs/index.html` to verify the generated app list.
 
 ## Learn More
 

--- a/app-index.csv
+++ b/app-index.csv
@@ -1,3 +1,3 @@
-﻿#,name,description,origin,model,tags,explainer post,notes
+#,name,description,origin,model,tags,explainer post,notes
 1,project-management-simulation,applying Friston's active inference to a project scenario,Claude,Cant remember,"active_inference, generative_model, prediction_error, surprise",,
 2,project-dynamics-simulator,introduce non-linear relationships into a project model which affect teams and performance,Claude,Cant remember,"gamification, feedback_loops, non_linearity, behaviour, learning,",,"Real projects are not just made up of task nodes connected by dependency edges. There are regular circles of daily activites, monthly progress review actions etc. There is negative feedback pushing back on attempted initaitives. there are positive reinforcing loops initiated sometimes after the first or second task has been done"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "start": "BROWSER=none WDS_SOCKET_PORT=0 vite --port 3000",
-    "build": "APP=project-management-simulation vite build && APP=project-dynamics-simulator vite build && cp index.html docs/index.html && cp app-index.csv docs/app-index.csv && cp -r pics docs/pics",
+    "build": "node scripts/build-all.js",
     "preview": "vite preview",
     "test": "vitest"
   },

--- a/scripts/build-all.js
+++ b/scripts/build-all.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+import { readdirSync, statSync, cpSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { execSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = dirname(__dirname);
+const appsDir = join(root, 'apps');
+const docsDir = join(root, 'docs');
+
+mkdirSync(docsDir, { recursive: true });
+
+const apps = readdirSync(appsDir).filter(app =>
+  statSync(join(appsDir, app)).isDirectory()
+);
+
+for (const app of apps) {
+  console.log(`Building ${app}...`);
+  execSync('vite build', { stdio: 'inherit', cwd: root, env: { ...process.env, APP: app } });
+}
+
+cpSync(join(root, 'index.html'), join(docsDir, 'index.html'));
+cpSync(join(root, 'app-index.csv'), join(docsDir, 'app-index.csv'));
+cpSync(join(root, 'pics'), join(docsDir, 'pics'), { recursive: true });
+


### PR DESCRIPTION
## Summary
- remove BOM from `app-index.csv`
- add `scripts/build-all.js` to build every app automatically
- update docs about multiple apps and the build process

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851ebc2f55c8332a896786069371303