### PR TITLE
Fix indentation in portfolio test

### DIFF
--- a/apps/portfolio-state-machine/src/App.test.jsx
+++ b/apps/portfolio-state-machine/src/App.test.jsx
@@ -2,7 +2,7 @@ import { expect, test } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import App from './App'
 
- test('renders portfolio heading', () => {
+test('renders portfolio heading', () => {
   render(<App />)
   const heading = screen.getByText(/Portfolio Management App/i)
   expect(heading).toBeDefined()


### PR DESCRIPTION
## Summary
- fix indentation in `App.test.jsx` for portfolio state machine

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68532f2016948332a113830c37aaa622