### PR TITLE
Fix import in stakeholder network graph

### DIFF
--- a/apps/stakeholder-network-graph/src/App.jsx
+++ b/apps/stakeholder-network-graph/src/App.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ForceGraph2D from 'react-force-graph';
+import { ForceGraph2D } from 'react-force-graph';
 import './App.css';
 
 export default function App() {


### PR DESCRIPTION
## Summary
- fix import for React Force Graph to use named export

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68547fd60d8c83328d549df40b63d156