### PR TITLE
Add tooltips and instructions to network graph

### DIFF
--- a/apps/stakeholder-network-graph/src/App.css
+++ b/apps/stakeholder-network-graph/src/App.css
@@ -1,2 +1,12 @@
-main {
+.app-container {
+  font-family: sans-serif;
+  padding: 1rem;
+}
+
+button {
+  margin-bottom: 0.5rem;
+}
+
+.instructions {
+  margin-bottom: 1rem;
 }

--- a/apps/stakeholder-network-graph/src/App.jsx
+++ b/apps/stakeholder-network-graph/src/App.jsx
@@ -1,8 +1,10 @@
-import React from 'react';
-import ForceGraph2D from 'react-force-graph-2d';
-import './App.css';
+import React, { useState } from 'react'
+import ForceGraph2D from 'react-force-graph-2d'
+import './App.css'
+import Instructions from './Instructions'
 
 export default function App() {
+  const [showInstructions, setShowInstructions] = useState(false)
   // Define the graph data schema
   const data = {
     nodes: [
@@ -47,13 +49,19 @@ export default function App() {
 
 
   return (
-    <div>
+    <div className="app-container">
       <h1>Interactive Stakeholder Graph</h1>
+      <button onClick={() => setShowInstructions(!showInstructions)}>
+        {showInstructions ? 'Hide' : 'Show'} Instructions
+      </button>
+      {showInstructions && <Instructions />}
       <ForceGraph2D
         graphData={data}
         nodeAutoColorBy="id"
+        nodeLabel="id"
+        linkLabel={(link) => link.label || ''}
       />
     </div>
-  );
+  )
 }
 

--- a/apps/stakeholder-network-graph/src/App.test.jsx
+++ b/apps/stakeholder-network-graph/src/App.test.jsx
@@ -1,10 +1,20 @@
-import { expect, test } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import App from './App';
+import { expect, test, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import App from './App'
+
+vi.mock('react-force-graph-2d', () => ({
+  default: () => <canvas data-testid="graph" />
+}))
 
 test('renders graph heading', () => {
   render(<App />);
   const heading = screen.getByText(/Interactive Stakeholder Graph/i);
   expect(heading).toBeDefined();
+});
+
+test('shows instruction toggle button', () => {
+  render(<App />);
+  const btn = screen.getByRole('button', { name: /show instructions/i });
+  expect(btn).toBeDefined();
 });
 

--- a/apps/stakeholder-network-graph/src/Instructions.jsx
+++ b/apps/stakeholder-network-graph/src/Instructions.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+export default function Instructions() {
+  return (
+    <section className="instructions">
+      <h2>Instructions</h2>
+      <p>
+        Hover over nodes and links to see their labels. Drag nodes to rearrange
+        them and scroll to zoom the view.
+      </p>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- update stakeholder-network-graph to display node/link tooltips
- add an Instructions component and toggle button
- style the page a bit
- mock canvas-based component in tests

## Testing
- `APP=stakeholder-network-graph npx vitest run`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68548ede418483328a04578f17caa3a1