### PR TITLE
Connect market timeline explorer app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,3 +68,13 @@ Each row of `app-index.csv` includes a `#` column. The number in this column cor
 - Add any additional graph libraries only once in the root `package.json` and run `npm install` so all apps share them.
 - Run locally with `APP=stakeholder-network-graph npm start`.
 
+### Pareto Projects
+- Located in `apps/pareto_projects/src/App.jsx` and bootstrapped by `apps/pareto_projects/src/index.jsx`.
+- Encourages teams to push project value beyond the usual Pareto frontier.
+- Run locally with `APP=pareto_projects npm start`.
+
+### Market Timeline Explorer
+- Located in `apps/market_timeline_explorer/src/app.jsx` and bootstrapped by `apps/market_timeline_explorer/src/index.jsx`.
+- Charts potential market shifts for project-management services through AGI and ASI milestones.
+- Run locally with `APP=market_timeline_explorer npm start`.
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project Apps
 
-This repository hosts a collection of small React applications. The main example is a **Project Management Simulation** implementing Active Inference principles. A second app, **Project Dynamics Simulator**, explores feedback loops in projects. A third app, **IT Project Sequential Decisions**, demonstrates sequential decision making for IT projects. A fourth app, **Portfolio State Machine**, models project portfolios using a state machine. A fifth app, **Stakeholder Analysis Dashboard**, visualises stakeholder perspectives. A sixth app, **Stakeholder Network Graph**, displays stakeholder relationships as an interactive graph. All apps are built with **Vite** and use [Recharts](https://recharts.org/) for charts.
+This repository hosts a collection of small React applications. The main example is a **Project Management Simulation** implementing Active Inference principles. A second app, **Project Dynamics Simulator**, explores feedback loops in projects. A third app, **IT Project Sequential Decisions**, demonstrates sequential decision making for IT projects. A fourth app, **Portfolio State Machine**, models project portfolios using a state machine. A fifth app, **Stakeholder Analysis Dashboard**, visualises stakeholder perspectives. A sixth app, **Stakeholder Network Graph**, displays stakeholder relationships as an interactive graph. A seventh app, **Pareto Projects**, examines pushing project value beyond the Pareto frontier. An eighth app, **Market Timeline Explorer**, charts potential market dynamics within the project‑management services industry. All apps are built with **Vite** and use [Recharts](https://recharts.org/) for charts.
 
 ## Getting Started
 
@@ -32,6 +32,14 @@ This repository hosts a collection of small React applications. The main example
   To work on the Stakeholder Network Graph app run:
   ```bash
   APP=stakeholder-network-graph npm start
+  ```
+  To work on the Pareto Projects app run:
+  ```bash
+  APP=pareto_projects npm start
+  ```
+  To work on the Market Timeline Explorer app run:
+  ```bash
+  APP=market_timeline_explorer npm start
   ```
   The page reloads automatically when files change.
 
@@ -71,6 +79,14 @@ This repository hosts a collection of small React applications. The main example
   Preview the Stakeholder Network Graph app with:
   ```bash
   APP=stakeholder-network-graph npm run preview
+  ```
+  Preview the Pareto Projects app with:
+  ```bash
+  APP=pareto_projects npm run preview
+  ```
+  Preview the Market Timeline Explorer app with:
+  ```bash
+  APP=market_timeline_explorer npm run preview
   ```
 
 ## Project Structure

--- a/apps/market_timeline_explorer/src/App.test.jsx
+++ b/apps/market_timeline_explorer/src/App.test.jsx
@@ -1,0 +1,9 @@
+import { expect, test } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import MarketTimelineExplorer from './app.jsx';
+
+test('renders winners heading', () => {
+  render(<MarketTimelineExplorer />);
+  const heading = screen.getByText(/Winners/i);
+  expect(heading).toBeDefined();
+});

--- a/apps/market_timeline_explorer/src/app.jsx
+++ b/apps/market_timeline_explorer/src/app.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo } from "react";
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
+import { Card, CardHeader, CardTitle, CardContent } from "./ui/card";
+import { Button } from "./ui/button";
+import { Badge } from "./ui/badge";
 import { ChevronLeft, ChevronRight, Sparkles } from "lucide-react";
 
 // --- Data ------------------------------------------------------------------

--- a/apps/market_timeline_explorer/src/index.jsx
+++ b/apps/market_timeline_explorer/src/index.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import '../../../src/common/index.css';
+import MarketTimelineExplorer from './app.jsx';
+import reportWebVitals from '../../../src/common/reportWebVitals';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <MarketTimelineExplorer />
+  </React.StrictMode>
+);
+
+reportWebVitals();

--- a/apps/market_timeline_explorer/src/ui/badge.jsx
+++ b/apps/market_timeline_explorer/src/ui/badge.jsx
@@ -1,0 +1,5 @@
+export function Badge({ className = '', ...props }) {
+  return (
+    <span className={`px-2 py-1 rounded text-xs font-medium ${className}`} {...props} />
+  );
+}

--- a/apps/market_timeline_explorer/src/ui/button.jsx
+++ b/apps/market_timeline_explorer/src/ui/button.jsx
@@ -1,0 +1,12 @@
+export function Button({ className = '', variant, size, ...props }) {
+  const variantClass =
+    variant === 'outline'
+      ? 'border'
+      : variant === 'secondary'
+      ? 'bg-gray-200'
+      : 'bg-blue-500 text-white';
+  const sizeClass = size === 'sm' ? 'px-2 py-1 text-sm' : 'px-4 py-2';
+  return (
+    <button className={`${variantClass} ${sizeClass} rounded ${className}`} {...props} />
+  );
+}

--- a/apps/market_timeline_explorer/src/ui/card.jsx
+++ b/apps/market_timeline_explorer/src/ui/card.jsx
@@ -1,0 +1,12 @@
+export function Card({ className = '', ...props }) {
+  return <div className={`border rounded shadow p-4 ${className}`} {...props} />;
+}
+export function CardHeader({ className = '', ...props }) {
+  return <div className={`mb-4 flex items-center justify-between ${className}`} {...props} />;
+}
+export function CardTitle({ className = '', ...props }) {
+  return <h2 className={`text-lg font-semibold ${className}`} {...props} />;
+}
+export function CardContent({ className = '', ...props }) {
+  return <div className={`space-y-2 ${className}`} {...props} />;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^14.4.3",
         "chart.js": "^4.4.1",
+        "lucide-react": "^0.523.0",
         "react": "^18.2.0",
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.2.0",
@@ -3212,6 +3213,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.523.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.523.0.tgz",
+      "integrity": "sha512-rUjQoy7egZT9XYVXBK1je9ckBnNp7qzRZOhLQx5RcEp2dCGlXo+mv6vf7Am4LimEcFBJIIZzSGfgTqc9QCrPSw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {
@@ -6479,6 +6489,12 @@
       "requires": {
         "yallist": "^3.0.2"
       }
+    },
+    "lucide-react": {
+      "version": "0.523.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.523.0.tgz",
+      "integrity": "sha512-rUjQoy7egZT9XYVXBK1je9ckBnNp7qzRZOhLQx5RcEp2dCGlXo+mv6vf7Am4LimEcFBJIIZzSGfgTqc9QCrPSw==",
+      "requires": {}
     },
     "lz-string": {
       "version": "1.4.4",

--- a/package.json
+++ b/package.json
@@ -7,12 +7,13 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.4.3",
+    "chart.js": "^4.4.1",
+    "lucide-react": "^0.523.0",
     "react": "^18.2.0",
+    "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.2.0",
     "react-force-graph-2d": "^1.27.1",
     "recharts": "^2.15.3",
-    "react-chartjs-2": "^5.2.0",
-    "chart.js": "^4.4.1",
     "web-vitals": "^3.1.0"
   },
   "overrides": {


### PR DESCRIPTION
## Summary
- wire up new market timeline explorer app with entry point and test
- include minimal UI components so the new app compiles
- document Pareto Projects and Market Timeline Explorer in README and AGENTS
- add lucide-react dependency

## Testing
- `npx vitest run`
- `APP=market_timeline_explorer npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_685bcffa4db08332b9ee845ad7e1fcbb