### PR TITLE
Fix DecisionPathGuide index entry

### DIFF
--- a/app-index.csv
+++ b/app-index.csv
@@ -8,4 +8,3 @@
 10,decision-path-guide,Interactive guide using an ontology-based questionnaire,Replit Python/Flask,,"decision, ontology",,
 8,market_timeline_explorer,An example of the possible market dynamics within the PM services industry through AGI and ASI milestones,ChatGPT,o3 Pro,"business_model, adoption",,
 9,Another-IT-project-simulation,A different twist on the sequential decision making in IT projects to cope with ongoing uncertainty- this one is more of a training game,cant remember,Cant remember,"decision, Uncertainty, gamification",,
-10,DecisionPathGuide,An ontology for decision making has been offered up as a series of steps to systematically set the context for a user's decision,,,"decision, ontology",,


### PR DESCRIPTION
## Summary
- remove duplicate `DecisionPathGuide` entry from `app-index.csv` so the index page links to the correct folder

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d12294dcc833294a7ca205f82c1c0