### PR TITLE
Fix benefits tree width

### DIFF
--- a/apps/scope-benefits-tree/src/App.css
+++ b/apps/scope-benefits-tree/src/App.css
@@ -5,5 +5,6 @@
 
 .tree-flow {
   height: 70vh;
+  width: 100%;
   border: 1px solid #ccc;
 }


### PR DESCRIPTION
## Summary
- fix `scope-benefits-tree` width so ReactFlow canvas shows correctly

## Testing
- `APP=scope-benefits-tree npm test`


------
https://chatgpt.com/codex/tasks/task_e_68630e5c84108332949d0a6ce483a6c5