### PR TITLE
Fix relative base for Vite builds

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -10,10 +10,8 @@ const appName = process.env.APP || 'project-management-simulation';
 
 export default defineConfig({
   root: resolve(__dirname, `apps/${appName}`),
-  base:
-    process.env.NODE_ENV === 'production'
-      ? `/React_proj-apps/apps/${appName}/`
-      : '/',
+  // make built paths portable to any host folder
+  base: process.env.NODE_ENV === 'production' ? './' : '/',
   build: {
     outDir: resolve(__dirname, `docs/apps/${appName}`),
   },


### PR DESCRIPTION
## Summary
- make built asset URLs relative to the hosting folder

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68643030c70c8332bdeb3161a07821cb