### PR TITLE
Fix React Flow height issue

### DIFF
--- a/apps/scope-benefits-tree/src/App.css
+++ b/apps/scope-benefits-tree/src/App.css
@@ -4,7 +4,7 @@
 }
 
 .tree-flow {
-  height: 70vh;
+  height: 100%;
   width: 100%;
   border: 1px solid #ccc;
 }

--- a/apps/scope-benefits-tree/src/App.jsx
+++ b/apps/scope-benefits-tree/src/App.jsx
@@ -47,10 +47,12 @@ export default function App() {
   return (
     <div className="app-container">
       <h1>Scope to Benefits Tree: East West Rail</h1>
-      <ReactFlow nodes={nodes} edges={edges} fitView className="tree-flow">
-        <Background />
-        <Controls />
-      </ReactFlow>
+      <div style={{ height: '600px', width: '100%' }}>
+        <ReactFlow nodes={nodes} edges={edges} fitView className="tree-flow">
+          <Background />
+          <Controls />
+        </ReactFlow>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- enforce explicit height on React Flow container in Scope Benefits Tree app
- rely on container height by setting `.tree-flow` to 100%

## Testing
- `APP=scope-benefits-tree npx vitest run`
- `APP=scope-benefits-tree npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68643ebb44608332ada355dd2b890fc8