### PR TITLE
Handle various screenshot extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,9 @@ A workflow in `.github/workflows/deploy.yml` builds the project and publishes th
 
 4. Add a screenshot and CSV entry
 
-5. Pick the next numeric ID and save a screenshot as `pics/<number>.png`. If the
-   image is missing the index automatically loads `pics/blank.png` instead.
+5. Pick the next numeric ID and save a screenshot under `pics/` using either
+   a `.png` or `.webp` extension. Case does not matter—the build process
+   normalises filenames and falls back to `pics/blank.png` if no image is found.
 
 6. Add a corresponding row to app-index.csv, filling out the name, description, and other fields. AGENTS.md explains how each CSV # value matches a screenshot. 
 

--- a/index.html
+++ b/index.html
@@ -68,10 +68,13 @@ function createCards(data){
         card.className='example-card';
         card.dataset.tags=item.tags;
         const img=document.createElement('img');
-        // Use the numeric id to load the matching screenshot in pics/
-        img.src='pics/'+item['#']+'.png';
+        const base='pics/'+item['#'];
         img.alt=item.name;
-        img.onerror=()=>{img.src='pics/blank.png';};
+        img.src=base+'.png';
+        img.onerror=()=>{
+            img.onerror=()=>{img.src='pics/blank.png';};
+            img.src=base+'.webp';
+        };
         card.appendChild(img);
         const title=document.createElement('h3');
         const link=document.createElement('a');

--- a/scripts/build-all.js
+++ b/scripts/build-all.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { readdirSync, statSync, cpSync, mkdirSync } from 'fs';
+import { readdirSync, statSync, cpSync, mkdirSync, renameSync } from 'fs';
 import { join, dirname } from 'path';
 import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
@@ -23,4 +23,13 @@ for (const app of apps) {
 cpSync(join(root, 'index.html'), join(docsDir, 'index.html'));
 cpSync(join(root, 'app-index.csv'), join(docsDir, 'app-index.csv'));
 cpSync(join(root, 'pics'), join(docsDir, 'pics'), { recursive: true });
+
+// Normalise image file extensions so the index page can load them reliably
+const picsDir = join(docsDir, 'pics');
+for (const file of readdirSync(picsDir)) {
+  const lower = file.toLowerCase();
+  if (file !== lower) {
+    renameSync(join(picsDir, file), join(picsDir, lower));
+  }
+}
 


### PR DESCRIPTION
## Summary
- normalize screenshot filenames during build so uppercase extensions still load
- try loading `.webp` when `.png` is missing
- clarify screenshot instructions in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68691c456fc883329c13bc44c90bff1f