### PR TITLE
Add skeleton apps for data maturity and Olaf dashboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,3 +78,10 @@ Each row of `app-index.csv` includes a `#` column. The number in this column cor
 - Charts potential market shifts for project-management services through AGI and ASI milestones.
 - Run locally with `APP=market_timeline_explorer npm start`.
 
+### Data Maturity Combined
+- Located in `apps/data-maturity-combined/src/App.tsx` and bootstrapped by `apps/data-maturity-combined/src/index.tsx`.
+- Run locally with `APP=data-maturity-combined npm start`.
+
+### Olaf Delivery Dashboard
+- Located in `apps/olaf-delivery-dashboard/src/App.tsx` and bootstrapped by `apps/olaf-delivery-dashboard/src/index.tsx`.
+- Run locally with `APP=olaf-delivery-dashboard npm start`.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ This repository hosts a collection of small React applications. The main example
   ```bash
   APP=copula-risk-analysis npm start
   ```
+  To work on the Data Maturity Combined app run:
+  ```bash
+  APP=data-maturity-combined npm start
+  ```
+  To work on the Olaf Delivery Dashboard app run:
+  ```bash
+  APP=olaf-delivery-dashboard npm start
+  ```
+
   The page reloads automatically when files change.
 
 3. **Run tests**
@@ -119,6 +128,15 @@ This repository hosts a collection of small React applications. The main example
   ```bash
   APP=copula-risk-analysis npm run preview
   ```
+  Preview the Data Maturity Combined app with:
+  ```bash
+  APP=data-maturity-combined npm run preview
+  ```
+  Preview the Olaf Delivery Dashboard app with:
+  ```bash
+  APP=olaf-delivery-dashboard npm run preview
+  ```
+
 
 ## Project Structure
 

--- a/app-index.csv
+++ b/app-index.csv
@@ -14,3 +14,5 @@
 13,scope-benefits-tree,Visualise how scope outputs grow into benefits for the East West Rail upgrade,cant remember,Cant remember,"scope, benefits",,
 14,project-controls-knowledge-graph,"a knowledge graph for project controls as a discipline, alongside a graph path for a PM learning about project controls",Claude,Sonnet 3.6,"knowledge_graph, multiple_perspectives, project_controls, learning, graph_pathways",,
 15,pm-software-evolution,"detailed evolution of project management software in the last 20 years, with all its branches and convergences,",Claude,Sonnet 3.7,"timeline, knowledge_graph_dependencies, roadmap",,
+16,data-maturity-combined,Combined metrics on data maturity across the enterprise,ChatGPT,Cant remember,"data_maturity, dashboard",,
+17,olaf-delivery-dashboard,Delivery dashboard for the OLAF project,ChatGPT,Cant remember,"delivery, metrics",,

--- a/apps/data-maturity-combined/index.html
+++ b/apps/data-maturity-combined/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="description" content="Data Maturity Combined" />
+    <title>Data Maturity Combined</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <p><a href="../../index.html">Back to app index</a></p>
+  </body>
+  <script type="module" src="./src/index.tsx"></script>
+</html>

--- a/apps/data-maturity-combined/src/App.css
+++ b/apps/data-maturity-combined/src/App.css
@@ -1,0 +1,5 @@
+.App {
+  font-family: sans-serif;
+  padding: 2rem;
+  text-align: center;
+}

--- a/apps/data-maturity-combined/src/App.test.tsx
+++ b/apps/data-maturity-combined/src/App.test.tsx
@@ -1,0 +1,9 @@
+import { expect, test } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import DataMaturityCombined from './App';
+
+test('renders heading', () => {
+  render(<DataMaturityCombined />);
+  const heading = screen.getByText(/Data Maturity Combined/i);
+  expect(heading).toBeDefined();
+});

--- a/apps/data-maturity-combined/src/App.tsx
+++ b/apps/data-maturity-combined/src/App.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import './App.css';
+
+const DataMaturityCombined: React.FC = () => (
+  <div className="App">
+    <h1>Data Maturity Combined</h1>
+  </div>
+);
+
+export default DataMaturityCombined;

--- a/apps/data-maturity-combined/src/index.tsx
+++ b/apps/data-maturity-combined/src/index.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import '../../../src/common/index.css';
+import App from './App';
+import reportWebVitals from '../../../src/common/reportWebVitals';
+
+const root = ReactDOM.createRoot(document.getElementById('root')!);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);
+
+reportWebVitals();

--- a/apps/olaf-delivery-dashboard/index.html
+++ b/apps/olaf-delivery-dashboard/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="description" content="Olaf Delivery Dashboard" />
+    <title>Olaf Delivery Dashboard</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <p><a href="../../index.html">Back to app index</a></p>
+  </body>
+  <script type="module" src="./src/index.tsx"></script>
+</html>

--- a/apps/olaf-delivery-dashboard/src/App.css
+++ b/apps/olaf-delivery-dashboard/src/App.css
@@ -1,0 +1,5 @@
+.App {
+  font-family: sans-serif;
+  padding: 2rem;
+  text-align: center;
+}

--- a/apps/olaf-delivery-dashboard/src/App.test.tsx
+++ b/apps/olaf-delivery-dashboard/src/App.test.tsx
@@ -1,0 +1,9 @@
+import { expect, test } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import OlafDeliveryDashboard from './App';
+
+test('renders heading', () => {
+  render(<OlafDeliveryDashboard />);
+  const heading = screen.getByText(/Olaf Delivery Dashboard/i);
+  expect(heading).toBeDefined();
+});

--- a/apps/olaf-delivery-dashboard/src/App.tsx
+++ b/apps/olaf-delivery-dashboard/src/App.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import './App.css';
+
+const OlafDeliveryDashboard: React.FC = () => (
+  <div className="App">
+    <h1>Olaf Delivery Dashboard</h1>
+  </div>
+);
+
+export default OlafDeliveryDashboard;

--- a/apps/olaf-delivery-dashboard/src/index.tsx
+++ b/apps/olaf-delivery-dashboard/src/index.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import '../../../src/common/index.css';
+import App from './App';
+import reportWebVitals from '../../../src/common/reportWebVitals';
+
+const root = ReactDOM.createRoot(document.getElementById('root')!);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);
+
+reportWebVitals();


### PR DESCRIPTION
## Summary
- create app folders for `data-maturity-combined` and `olaf-delivery-dashboard`
- add placeholder React components, CSS and tests
- document how to run the new apps in AGENTS.md and README
- extend app-index.csv with entries for the two apps

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68716b9e481c8332b8a9960b31047cf1