### PR TITLE
Fix occupancy app build path and update docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,3 +78,8 @@ Each row of `app-index.csv` includes a `#` column. The number in this column cor
 - Charts potential market shifts for project-management services through AGI and ASI milestones.
 - Run locally with `APP=market_timeline_explorer npm start`.
 
+### Building Site Occupancy Simulation
+- Located in `apps/building-site-occupancy-simulation/src/App.jsx` and bootstrapped by `apps/building-site-occupancy-simulation/src/index.jsx`.
+- Provides a NetLogo model simulating construction site occupancy over a 24‑hour period.
+- Run locally with `APP=building-site-occupancy-simulation npm start`.
+

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ This repository hosts a collection of small React applications. The main example
   ```bash
   APP=copula-risk-analysis npm start
   ```
+  To work on the Building Site Occupancy Simulation app run:
+  ```bash
+  APP=building-site-occupancy-simulation npm start
+  ```
   The page reloads automatically when files change.
 
 3. **Run tests**
@@ -118,6 +122,10 @@ This repository hosts a collection of small React applications. The main example
   Preview the Copula Risk Analysis app with:
   ```bash
   APP=copula-risk-analysis npm run preview
+  ```
+  Preview the Building Site Occupancy Simulation app with:
+  ```bash
+  APP=building-site-occupancy-simulation npm run preview
   ```
 
 ## Project Structure

--- a/apps/building-site-occupancy-simulation/index.html
+++ b/apps/building-site-occupancy-simulation/index.html
@@ -30,6 +30,6 @@
       <a href="../../index.html" class="back-link">&larr; Back to app index</a>
       <div id="root"></div>
     </div>
-    <script type="module" src="/apps/building-site-occupancy-simulation/src/index.jsx"></script>
+    <script type="module" src="/src/index.jsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- fix script path in building-site-occupancy-simulation index.html
- document how to run and preview the new app in README
- add app description to AGENTS instructions

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6883fcef74508332b6bf8e895e3b05f9