### PR TITLE
Add Tag Concurrence Explorer setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ This repository hosts a collection of small React applications. The main example
   ```bash
   APP=building-site-occupancy-simulation npm start
   ```
+  To work on the Tag Concurrence Explorer app run:
+  ```bash
+  APP=tag-concurrence-explorer npm start
+  ```
   The page reloads automatically when files change.
 
 3. **Run tests**
@@ -126,6 +130,10 @@ This repository hosts a collection of small React applications. The main example
   Preview the Building Site Occupancy Simulation app with:
   ```bash
   APP=building-site-occupancy-simulation npm run preview
+  ```
+  Preview the Tag Concurrence Explorer app with:
+  ```bash
+  APP=tag-concurrence-explorer npm run preview
   ```
 
 ## Project Structure

--- a/apps/tag-concurrence-explorer/index.html
+++ b/apps/tag-concurrence-explorer/index.html
@@ -8,7 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
-    <a href="../index.html">Back to app index</a>
+    <a href="../../index.html">Back to app index</a>
     <script type="module" src="./src/index.jsx"></script>
   </body>
 </html>

--- a/apps/tag-concurrence-explorer/src/App.test.jsx
+++ b/apps/tag-concurrence-explorer/src/App.test.jsx
@@ -1,0 +1,9 @@
+import { expect, test } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import App from './App';
+
+test('renders min edge weight label', () => {
+  render(<App />);
+  const label = screen.getByText(/Min edge weight/i);
+  expect(label).toBeDefined();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "lucide-react": "^0.523.0",
         "react": "^18.2.0",
         "react-chartjs-2": "^5.2.0",
+        "react-cytoscapejs": "^2.0.0",
         "react-dom": "^18.2.0",
         "react-force-graph-2d": "^1.27.1",
         "reactflow": "^11.11.4",
@@ -2225,6 +2226,16 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
+    "node_modules/cytoscape": {
+      "version": "3.32.1",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.32.1.tgz",
+      "integrity": "sha512-dbeqFTLYEwlFg7UGtcZhCCG/2WayX72zK3Sq323CEX29CY81tYfVhw1MIdduCtpstB0cTOhJswWlM/OEB3Xp+Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/d3": {
       "version": "7.9.0",
       "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
@@ -4066,6 +4077,19 @@
       "peerDependencies": {
         "chart.js": "^4.1.1",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-cytoscapejs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-cytoscapejs/-/react-cytoscapejs-2.0.0.tgz",
+      "integrity": "sha512-t3SSl1DQy7+JQjN+8QHi1anEJlM3i3aAeydHTsJwmjo/isyKK7Rs7oCvU6kZsB9NwZidzZQR21Vm2PcBLG/Tjg==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.19",
+        "react": ">=15.0.0"
       }
     },
     "node_modules/react-dom": {
@@ -6401,6 +6425,12 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
+    "cytoscape": {
+      "version": "3.32.1",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.32.1.tgz",
+      "integrity": "sha512-dbeqFTLYEwlFg7UGtcZhCCG/2WayX72zK3Sq323CEX29CY81tYfVhw1MIdduCtpstB0cTOhJswWlM/OEB3Xp+Q==",
+      "peer": true
+    },
     "d3": {
       "version": "7.9.0",
       "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
@@ -7690,6 +7720,14 @@
       "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
       "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
       "requires": {}
+    },
+    "react-cytoscapejs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-cytoscapejs/-/react-cytoscapejs-2.0.0.tgz",
+      "integrity": "sha512-t3SSl1DQy7+JQjN+8QHi1anEJlM3i3aAeydHTsJwmjo/isyKK7Rs7oCvU6kZsB9NwZidzZQR21Vm2PcBLG/Tjg==",
+      "requires": {
+        "prop-types": "^15.8.1"
+      }
     },
     "react-dom": {
       "version": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lucide-react": "^0.523.0",
     "react": "^18.2.0",
     "react-chartjs-2": "^5.2.0",
+    "react-cytoscapejs": "^2.0.0",
     "react-dom": "^18.2.0",
     "react-force-graph-2d": "^1.27.1",
     "reactflow": "^11.11.4",


### PR DESCRIPTION
## Summary
- fix link back to app index
- add minimal test for new app
- document Tag Concurrence Explorer in README
- install `react-cytoscapejs`

## Testing
- `npm test --silent`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6885532931c48332b6fa2b13aeacea8a