### PR TITLE
Fix tag concurrence JSON generation

### DIFF
--- a/apps/tag-concurrence-explorer/src/App.jsx
+++ b/apps/tag-concurrence-explorer/src/App.jsx
@@ -15,7 +15,7 @@ export default function App(){
   const [data, setData] = useState({ nodes: [], edges: [] });
 
   useEffect(() => {
-    fetch(new URL('../tag_concurrence_graph.json', import.meta.url).href)
+    fetch('./tag_concurrence_graph.json')
       .then(r => r.json())
       .then(setData)
       .catch(err => console.error('Failed to load graph data', err));

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   },
   "scripts": {
     "start": "BROWSER=none WDS_SOCKET_PORT=0 vite --port 3000",
+    "prebuild": "node scripts/generate-tag-concurrence-graph.js",
     "build": "node scripts/build-all.js",
-    "postbuild": "node scripts/generate-tag-concurrence-graph.js",
     "preview": "vite preview",
     "test": "vitest"
   },


### PR DESCRIPTION
## Summary
- generate tag concurrence graph before building apps
- reference data file with a simple relative fetch

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68875e4fa2c083328a18a21b8113894b