### PR TITLE
Add tooltips to Tag Concurrence Explorer nodes

### DIFF
--- a/apps/tag-concurrence-explorer/src/App.css
+++ b/apps/tag-concurrence-explorer/src/App.css
@@ -1,1 +1,2 @@
-.cy-container{border:1px solid #ccc;border-radius:4px;background:white;}
+.cy-container{position:relative;border:1px solid #ccc;border-radius:4px;background:white;}
+.cy-tooltip{position:absolute;pointer-events:none;background:rgba(0,0,0,0.75);color:#fff;padding:2px 4px;border-radius:4px;font-size:12px;white-space:nowrap;transform:translate(-50%,-150%);}

--- a/apps/tag-concurrence-explorer/src/App.jsx
+++ b/apps/tag-concurrence-explorer/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect } from 'react';
+import React, { useState, useMemo, useEffect, useRef, useCallback } from 'react';
 import CytoscapeComponent from 'react-cytoscapejs';
 import './App.css';
 
@@ -13,6 +13,21 @@ export default function App(){
   const [threshold, setThreshold] = useState(0);
   const [layout, setLayout] = useState('cose');
   const [data, setData] = useState({ nodes: [], edges: [] });
+  const [tooltip, setTooltip] = useState(null);
+  const cyRef = useRef(null);
+
+  const handleCy = useCallback((cy) => {
+    cyRef.current = cy;
+    cy.on('mouseover', 'node', (evt) => {
+      const { x, y } = evt.renderedPosition || evt.position;
+      setTooltip({ label: evt.target.data('id'), x, y });
+    });
+    cy.on('mouseout', 'node', () => setTooltip(null));
+    cy.on('mousemove', 'node', (evt) => {
+      const { x, y } = evt.renderedPosition || evt.position;
+      setTooltip(t => t ? { ...t, x, y } : t);
+    });
+  }, []);
 
   useEffect(() => {
     fetch('./tag_concurrence_graph.json')
@@ -34,7 +49,12 @@ export default function App(){
         </select>
       </div>
       <div className="cy-container">
-        <CytoscapeComponent elements={elements} style={{ width: '100%', height: '100%' }} layout={{ name: layout }} />
+        <CytoscapeComponent cy={handleCy} elements={elements} style={{ width: '100%', height: '100%' }} layout={{ name: layout }} />
+        {tooltip && (
+          <div className="cy-tooltip" style={{ left: tooltip.x, top: tooltip.y }}>
+            {tooltip.label}
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- show tooltips with node ids on hover in Tag Concurrence Explorer
- style tooltip overlay

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887fcaf53e48332a9cd4b1766d0fb04