### PR TITLE
Set grid view as default for Tag Concurrence Explorer

### DIFF
--- a/apps/tag-concurrence-explorer/src/App.jsx
+++ b/apps/tag-concurrence-explorer/src/App.jsx
@@ -11,7 +11,8 @@ function elementsFromData(data, threshold){
 
 export default function App(){
   const [threshold, setThreshold] = useState(0);
-  const [layout, setLayout] = useState('cose');
+  // default layout is grid so users immediately see a structured view
+  const [layout, setLayout] = useState('grid');
   const [data, setData] = useState({ nodes: [], edges: [] });
   const [tooltip, setTooltip] = useState(null);
   const cyRef = useRef(null);

--- a/apps/tag-concurrence-explorer/src/App.test.jsx
+++ b/apps/tag-concurrence-explorer/src/App.test.jsx
@@ -1,9 +1,27 @@
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import App from './App';
+
+// Mock Cytoscape component and network fetch to avoid DOM/canvas issues
+vi.mock('react-cytoscapejs', () => ({
+  __esModule: true,
+  default: () => <div data-testid="cy" />,
+}));
+
+beforeEach(() => {
+  global.fetch = vi.fn(() => Promise.resolve({
+    json: () => Promise.resolve({ nodes: [], edges: [] })
+  }));
+});
 
 test('renders min edge weight label', () => {
   render(<App />);
   const label = screen.getByText(/Min edge weight/i);
   expect(label).toBeDefined();
+});
+
+test('defaults to grid layout', () => {
+  render(<App />);
+  const select = screen.getByRole('combobox');
+  expect(select.value).toBe('grid');
 });


### PR DESCRIPTION
## Summary
- default the Tag Concurrence Explorer to `grid` layout
- mock Cytoscape and fetch in tests so the app tests run in jsdom
- add regression test verifying the default layout

## Testing
- `APP=tag-concurrence-explorer npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688925068a988332b69c442d2c89a620