### PR TITLE
Add usage guidance and controls to tag concurrence explorer

### DIFF
--- a/apps/tag-concurrence-explorer/src/App.css
+++ b/apps/tag-concurrence-explorer/src/App.css
@@ -1,2 +1,18 @@
-.cy-container{position:relative;border:1px solid #ccc;border-radius:4px;background:white;}
-.cy-tooltip{position:absolute;pointer-events:none;background:rgba(0,0,0,0.75);color:#fff;padding:2px 4px;border-radius:4px;font-size:12px;white-space:nowrap;transform:translate(-50%,-150%);}
+.cy-container {
+  position: relative;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: white;
+}
+
+.cy-tooltip {
+  position: absolute;
+  pointer-events: none;
+  background: rgba(0, 0, 0, 0.75);
+  color: #fff;
+  padding: 2px 4px;
+  border-radius: 4px;
+  font-size: 12px;
+  white-space: nowrap;
+  transform: translate(-50%, -150%);
+}

--- a/apps/tag-concurrence-explorer/src/App.jsx
+++ b/apps/tag-concurrence-explorer/src/App.jsx
@@ -15,6 +15,7 @@ export default function App(){
   const [layout, setLayout] = useState('grid');
   const [data, setData] = useState({ nodes: [], edges: [] });
   const [tooltip, setTooltip] = useState(null);
+  const [showLabels, setShowLabels] = useState(false);
   const cyRef = useRef(null);
 
   const handleCy = useCallback((cy) => {
@@ -38,8 +39,40 @@ export default function App(){
   }, []);
 
   const elements = useMemo(() => elementsFromData(data, threshold), [data, threshold]);
+  const stylesheet = useMemo(() => ([
+    { selector: 'node', style: { label: showLabels ? 'data(id)' : '' } }
+  ]), [showLabels]);
+
+  const handleDownload = () => {
+    if (cyRef.current) {
+      const uri = cyRef.current.png({ full: true });
+      const a = document.createElement('a');
+      a.href = uri;
+      a.download = 'tag-concurrence.png';
+      a.click();
+    }
+  };
+
   return (
     <div className="app-container">
+      <h1>Concepts in the apps on this website: a visualiser for document tags</h1>
+      <p className="getting-started">You will initially see one big node. Just click on "Concentric" or "Grid" layout to get started. To see tags, hover over nodes.</p>
+      <section className="instructions">
+        <h2>How to Use</h2>
+        <h3>Basic Navigation</h3>
+        <ul>
+          <li>Click and drag to move around the graph</li>
+          <li>Scroll to zoom in/out</li>
+          <li>Click nodes to see their connections</li>
+        </ul>
+        <h3>Features</h3>
+        <ul>
+          <li>Switch between different layouts using the dropdown</li>
+          <li>Filter connections by weight using the slider</li>
+          <li>Toggle node labels on/off</li>
+          <li>Download your current view</li>
+        </ul>
+      </section>
       <div className="controls">
         <label>Min edge weight: {threshold}</label>
         <input type="range" min="0" max="10" value={threshold} onChange={e=>setThreshold(+e.target.value)}/>
@@ -48,15 +81,26 @@ export default function App(){
           <option value="concentric">Concentric</option>
           <option value="grid">Grid</option>
         </select>
+        <button onClick={()=>setShowLabels(s=>!s)}>{showLabels ? 'Hide Labels' : 'Show Labels'}</button>
+        <button onClick={handleDownload}>Download</button>
       </div>
       <div className="cy-container">
-        <CytoscapeComponent cy={handleCy} elements={elements} style={{ width: '100%', height: '100%' }} layout={{ name: layout }} />
+        <CytoscapeComponent cy={handleCy} elements={elements} stylesheet={stylesheet} style={{ width: '100%', height: '100%' }} layout={{ name: layout }} />
         {tooltip && (
           <div className="cy-tooltip" style={{ left: tooltip.x, top: tooltip.y }}>
             {tooltip.label}
           </div>
         )}
       </div>
+      <section className="about">
+        <h2>About This Tool</h2>
+        <p>This web-based visualization displays relationships between tags using interactive network graphs. Features include:</p>
+        <ul>
+          <li>Community detection algorithms</li>
+          <li>Node sizes weighted by tag frequency</li>
+          <li>Interactive filtering capabilities</li>
+        </ul>
+      </section>
     </div>
   );
 }

--- a/apps/tag-concurrence-explorer/src/App.test.jsx
+++ b/apps/tag-concurrence-explorer/src/App.test.jsx
@@ -1,5 +1,5 @@
 import { expect, test, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import App from './App';
 
 // Mock Cytoscape component and network fetch to avoid DOM/canvas issues
@@ -24,4 +24,13 @@ test('defaults to grid layout', () => {
   render(<App />);
   const select = screen.getByRole('combobox');
   expect(select.value).toBe('grid');
+});
+
+test('renders heading and allows toggling labels', () => {
+  render(<App />);
+  const heading = screen.getByRole('heading', { name: /Concepts in the apps/i });
+  expect(heading).toBeDefined();
+  const button = screen.getByRole('button', { name: /show labels/i });
+  fireEvent.click(button);
+  expect(button.textContent.toLowerCase()).toContain('hide');
 });

--- a/apps/tag-concurrence-explorer/src/index.css
+++ b/apps/tag-concurrence-explorer/src/index.css
@@ -1,4 +1,35 @@
-body { margin:0;font-family:sans-serif;background:#f7f9fc;}
-.app-container{padding:1rem;max-width:960px;margin:0 auto;}
-.controls{margin-bottom:1rem;display:flex;gap:1rem;align-items:center;}
-.cy-container{height:600px;border:1px solid #ccc;border-radius:4px;background:#fff;}
+body {
+  margin: 0;
+  font-family: sans-serif;
+  background: #f7f9fc;
+}
+
+.app-container {
+  padding: 1rem;
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.getting-started {
+  margin-bottom: 1rem;
+}
+
+.instructions,
+.about {
+  margin-bottom: 1rem;
+}
+
+.controls {
+  margin-bottom: 1rem;
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.cy-container {
+  height: 600px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: #fff;
+}


### PR DESCRIPTION
## Summary
- Add descriptive heading, getting started note, and usage instructions to Tag Concurrence Explorer
- Provide toggle for node labels and option to download current graph view
- Document tool features and background in an About section, with accompanying styles and tests

## Testing
- `APP=tag-concurrence-explorer npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a6347f2474833280eaaac361b1ecfd