### PR TITLE
Filter orphan nodes in tag concurrence explorer

### DIFF
--- a/apps/tag-concurrence-explorer/src/App.jsx
+++ b/apps/tag-concurrence-explorer/src/App.jsx
@@ -2,10 +2,17 @@ import React, { useState, useMemo, useEffect, useRef, useCallback } from 'react'
 import CytoscapeComponent from 'react-cytoscapejs';
 import './App.css';
 
-function elementsFromData(data, threshold){
+export function elementsFromData(data, threshold){
   const filteredEdges = data.edges.filter(e=>e.weight>=threshold);
-  const nodes = data.nodes.map(n=>({ data:{ id:n.id, weight:n.weight}}));
-  const edges = filteredEdges.map(e=>({ data:{ id:`${e.source}-${e.target}`, source:e.source, target:e.target, weight:e.weight}}));
+  const connectedIds = new Set();
+  filteredEdges.forEach(e => {
+    connectedIds.add(e.source);
+    connectedIds.add(e.target);
+  });
+  const nodes = data.nodes
+    .filter(n => connectedIds.has(n.id))
+    .map(n => ({ data: { id: n.id, weight: n.weight } }));
+  const edges = filteredEdges.map(e => ({ data: { id: `${e.source}-${e.target}`, source: e.source, target: e.target, weight: e.weight } }));
   return [...nodes, ...edges];
 }
 

--- a/apps/tag-concurrence-explorer/src/App.test.jsx
+++ b/apps/tag-concurrence-explorer/src/App.test.jsx
@@ -1,6 +1,6 @@
 import { expect, test, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import App from './App';
+import App, { elementsFromData } from './App';
 
 // Mock Cytoscape component and network fetch to avoid DOM/canvas issues
 vi.mock('react-cytoscapejs', () => ({
@@ -33,4 +33,22 @@ test('renders heading and allows toggling labels', () => {
   const button = screen.getByRole('button', { name: /show labels/i });
   fireEvent.click(button);
   expect(button.textContent.toLowerCase()).toContain('hide');
+});
+
+test('filters nodes without remaining edges', () => {
+  const sample = {
+    nodes: [
+      { id: 'a', weight: 1 },
+      { id: 'b', weight: 1 },
+      { id: 'c', weight: 1 }
+    ],
+    edges: [{ source: 'a', target: 'b', weight: 3 }]
+  };
+  let elems = elementsFromData(sample, 2);
+  const ids = elems.map(e => e.data.id);
+  expect(ids).toContain('a');
+  expect(ids).toContain('b');
+  expect(ids).not.toContain('c');
+  elems = elementsFromData(sample, 4);
+  expect(elems.length).toBe(0);
 });


### PR DESCRIPTION
## Summary
- hide nodes that lose all edges when threshold increases
- test elementsFromData to ensure orphan nodes are removed

## Testing
- `APP=tag-concurrence-explorer npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68a6423bb4b883328355ad84c294a56f